### PR TITLE
fix: this.isLevelVisible is not a function

### DIFF
--- a/console++.js
+++ b/console++.js
@@ -302,25 +302,25 @@ console.error = function(msg) {
         _console.error.apply(this, _decorateArgs(arguments, _LEVELS.ERROR));
         _invokeOnOutput(msg, _LEVELS.ERROR);
      }
-};
+}.bind(console);
 console.warn = function(msg) {
     if (arguments.length > 0 && this.isLevelVisible(_LEVELS.WARN)) {
         _console.warn.apply(this, _decorateArgs(arguments, _LEVELS.WARN));
         _invokeOnOutput(msg, _LEVELS.WARN);
     }
-};
+}.bind(console);
 console.info = function(msg) {
     if (arguments.length > 0 && this.isLevelVisible(_LEVELS.INFO)) {
         _console.info.apply(this, _decorateArgs(arguments, _LEVELS.INFO));
         _invokeOnOutput(msg, _LEVELS.INFO);
     }
-};
+}.bind(console);
 console.debug = function(msg) {
     if (arguments.length > 0 && this.isLevelVisible(_LEVELS.DEBUG)) {
         _console.debug.apply(this, _decorateArgs(arguments, _LEVELS.DEBUG));
         _invokeOnOutput(msg, _LEVELS.DEBUG);
     }
-};
+}.bind(console);
 console.log = function(msg) {
     if (arguments.length > 0) {
         _console.log.apply(this, arguments);


### PR DESCRIPTION
Error describe in #19 is caused by "this" in JavaScript.

```javascript
require("consoleplusplus")

console.info("it works fine");
// "this" is resolved to "console"

const infoFn = console.info;
infoFn("this is not console")
// "this" is resolved to the global object.
// And isLevelVisible isn't defined there.
```

It seems the implementation of unhandled promise rejection has been changed since node v12. That's why `this` is not correct any more:
https://github.com/nodejs/node/blob/835b85d5e992bc6a1b8b0a6d95068bb357d1fffc/lib/internal/process/warning.js#L41-L45

This commit explicitly sets `this` to `console` in order to avoid the error.

Tested in Node v11.15.0, v12.20.1 and v14.15.4.

Fixes #19 